### PR TITLE
feat: add support for setThermostatMode

### DIFF
--- a/src/domain/alexa/index.ts
+++ b/src/domain/alexa/index.ts
@@ -58,6 +58,7 @@ export const SupportedActions = {
   turnOff: 'turnOff',
   setBrightness: 'setBrightness',
   setTargetTemperature: 'setTargetTemperature',
+  setThermostatMode: 'setThermostatMode',
 } as const;
 
 export type SupportedActionsType = keyof typeof SupportedActions;

--- a/src/mapper/thermostat-mapper.ts
+++ b/src/mapper/thermostat-mapper.ts
@@ -12,3 +12,14 @@ export const mapAlexaModeToHomeKit = (
     .with('COOL', constant(characteristic.TargetHeatingCoolingState.COOL))
     .with('AUTO', constant(characteristic.TargetHeatingCoolingState.AUTO))
     .otherwise(constant(characteristic.TargetHeatingCoolingState.OFF));
+
+
+export const mapHomekitModeToAlexa = (
+    value: number,
+    characteristic: typeof Characteristic,
+) =>
+    match(value)
+        .with(characteristic.TargetHeatingCoolingState.OFF, constant('OFF'))
+        .with(characteristic.TargetHeatingCoolingState.HEAT, constant('HEAT'))
+        .with(characteristic.TargetHeatingCoolingState.COOL, constant('COOL'))
+        .otherwise(constant('AUTO'));


### PR DESCRIPTION
Addition of support for setThermostatMode action. now you can choose between HEAT, COOL, AUTO and OFF.

for OFF, since there are some cases where the device does not support it from setThermostatMode, I added a power off from PowerController in the catch section. 

Tested on Haier AC :
    "deviceType": "THERMOSTAT",
    "deviceModelType": "AS35TAMHRA-C",