### PR TITLE
feat (#82): Added support to  relative humidity levels for thermostats

### DIFF
--- a/src/accessory/thermostat-accessory.ts
+++ b/src/accessory/thermostat-accessory.ts
@@ -312,6 +312,12 @@ export default class ThermostatAccessory extends BaseAccessory {
     }
     const units = maybeTemp.value.scale.toLowerCase() as TemperatureScale;
     const newTemp = tempMapper.mapHomeKitTempToAlexa(value, units);
+    try {
+      const userSelectedState = await this.handleTargetStateGet();
+      await this.handleTargetStateSet(userSelectedState);
+    } catch (e) {
+      this.logWithContext('debug', 'Attempting to reset thermostat state failure, this might not be an issue');
+    }
     return pipe(
       this.platform.alexaApi.setDeviceState(
         this.device.id,

--- a/src/domain/alexa/index.ts
+++ b/src/domain/alexa/index.ts
@@ -51,6 +51,7 @@ export const SupportedNamespaces = {
   'Alexa.TemperatureSensor': 'Alexa.TemperatureSensor',
   'Alexa.ThermostatController': 'Alexa.ThermostatController',
   'Alexa.RangeController': 'Alexa.RangeController',
+  'Alexa.HumiditySensor': 'Alexa.HumiditySensor',
 } as const;
 
 export type SupportedNamespacesType = keyof typeof SupportedNamespaces;

--- a/src/domain/alexa/thermostat.ts
+++ b/src/domain/alexa/thermostat.ts
@@ -10,6 +10,7 @@ export interface ThermostatState {
 export const ThermostatNamespaces = {
   'Alexa.TemperatureSensor': 'Alexa.TemperatureSensor',
   'Alexa.ThermostatController': 'Alexa.ThermostatController',
+  'Alexa.HumiditySensor': 'Alexa.HumiditySensor',
 } as const;
 
 export type ThermostatNamespacesType = keyof typeof ThermostatNamespaces;


### PR DESCRIPTION
In reference to feature request #82 

This is just one of my first times playing around with homebridge plugins so there might be better ways to accomplish this, but the implementation seemed pretty straightforward to me.
Consider this as a PoC for I'm not totally sure on what would happen if a thermostat doesn't measure humidity (to my understanding HB normalizes missing/wrong values so actually nothing bad?).

While checking the logs generated by `logDeviceInfo` for my thermostat current state, I noticed this:

```
[02/01/2024, 15:46:33] [homebridge-alexa-smarthome] Thermostat ::: Current state: [
{
...
{
    "namespace": "Alexa.HumiditySensor",
    "name": "relativeHumidity",
    "value": 37
  },
...
}]
```

I then followed what `handleCurrentTempGet` did to retrieve the current temperature and made a modified copy of it to wotk on the `Alexa.HuniditySensor` namespace and, sure enough...

![92D5B841-B8E4-489C-9BF7-E2E035CC1C16_1_102_o](https://github.com/joeyhage/homebridge-alexa-smarthome/assets/20660951/90b66db1-092c-4874-bbf5-28fd2cd4692e)
 