### PR TITLE
Implement onGet for CurrentHeatingCoolingState

### DIFF
--- a/src/domain/alexa/index.ts
+++ b/src/domain/alexa/index.ts
@@ -54,6 +54,8 @@ export const SupportedNamespaces = {
   'Alexa.ThermostatController': 'Alexa.ThermostatController',
   'Alexa.RangeController': 'Alexa.RangeController',
   'Alexa.HumiditySensor': 'Alexa.HumiditySensor',
+  'Alexa.ThermostatController.HVAC.Components':
+    'Alexa.ThermostatController.HVAC.Components',
 } as const;
 
 export type SupportedNamespacesType = keyof typeof SupportedNamespaces;

--- a/src/domain/alexa/thermostat.ts
+++ b/src/domain/alexa/thermostat.ts
@@ -11,6 +11,8 @@ export const ThermostatNamespaces = {
   'Alexa.TemperatureSensor': 'Alexa.TemperatureSensor',
   'Alexa.ThermostatController': 'Alexa.ThermostatController',
   'Alexa.HumiditySensor': 'Alexa.HumiditySensor',
+  'Alexa.ThermostatController.HVAC.Components':
+    'Alexa.ThermostatController.HVAC.Components',
 } as const;
 
 export type ThermostatNamespacesType = keyof typeof ThermostatNamespaces;

--- a/src/mapper/thermostat-mapper.ts
+++ b/src/mapper/thermostat-mapper.ts
@@ -13,13 +13,12 @@ export const mapAlexaModeToHomeKit = (
     .with('AUTO', constant(characteristic.TargetHeatingCoolingState.AUTO))
     .otherwise(constant(characteristic.TargetHeatingCoolingState.OFF));
 
-
 export const mapHomekitModeToAlexa = (
-    value: number,
-    characteristic: typeof Characteristic,
+  value: number,
+  characteristic: typeof Characteristic,
 ) =>
-    match(value)
-        .with(characteristic.TargetHeatingCoolingState.OFF, constant('OFF'))
-        .with(characteristic.TargetHeatingCoolingState.HEAT, constant('HEAT'))
-        .with(characteristic.TargetHeatingCoolingState.COOL, constant('COOL'))
-        .otherwise(constant('AUTO'));
+  match(value)
+    .with(characteristic.TargetHeatingCoolingState.OFF, constant('OFF'))
+    .with(characteristic.TargetHeatingCoolingState.HEAT, constant('HEAT'))
+    .with(characteristic.TargetHeatingCoolingState.COOL, constant('COOL'))
+    .otherwise(constant('AUTO'));


### PR DESCRIPTION
## Description

Implements onGet for CurrentHeatingCoolingState so that it is not always set to OFF. Runs a reduce on the ThermostatState and adds a 1 if heat is on, and 2 if it is on cool. It is initialized at 0 so that if nothing is set it stays off.

## Testing
Verified with my Alexa thermostats