### PR TITLE
Fix: Display proper HVAC operation

### DIFF
--- a/src/accessory/thermostat-accessory.ts
+++ b/src/accessory/thermostat-accessory.ts
@@ -15,21 +15,21 @@ import {
   SupportedActionsType,
   SupportedNamespacesType,
 } from '../domain/alexa';
-import {
-  ThermostatNamespaces,
-  ThermostatNamespacesType,
-  ThermostatState,
-} from '../domain/alexa/thermostat';
-import * as tempMapper from '../mapper/temperature-mapper';
-import * as tstatMapper from '../mapper/thermostat-mapper';
-import BaseAccessory from './base-accessory';
+import { SwitchState } from '../domain/alexa/switch';
 import {
   Temperature,
   TemperatureScale,
   isTemperatureValue,
 } from '../domain/alexa/temperature';
-import { SwitchState } from '../domain/alexa/switch';
+import {
+  ThermostatNamespaces,
+  ThermostatNamespacesType,
+  ThermostatState,
+} from '../domain/alexa/thermostat';
 import * as mapper from '../mapper/power-mapper';
+import * as tempMapper from '../mapper/temperature-mapper';
+import * as tstatMapper from '../mapper/thermostat-mapper';
+import BaseAccessory from './base-accessory';
 
 export default class ThermostatAccessory extends BaseAccessory {
   static requiredOperations: SupportedActionsType[] = ['setTargetTemperature'];
@@ -276,19 +276,26 @@ export default class ThermostatAccessory extends BaseAccessory {
       'Alexa.ThermostatController.HVAC.Components';
     const alexaValueNameHeat = 'primaryHeaterOperation';
     const alexaValueNameCool = 'coolerOperation';
+    const alexaValueValueOFF = 'OFF';
 
     const determineCurrentState = flow(
       O.map<ThermostatState[], number>((thermostatStateArr) =>
         pipe(
           thermostatStateArr,
-          A.findFirstMap(({ namespace, name }) => {
-            if (namespace === alexaNamespace && name === alexaValueNameHeat) {
-              return O.of(this.Characteristic.CurrentHeatingCoolingState.HEAT);
-            } else if (
-              namespace === alexaNamespace &&
-              name === alexaValueNameCool
-            ) {
-              return O.of(this.Characteristic.CurrentHeatingCoolingState.COOL);
+          A.findFirstMap(({ namespace, name, value }) => {
+            if (value !== alexaValueValueOFF) {
+              if (namespace === alexaNamespace && name === alexaValueNameHeat) {
+                return O.of(
+                  this.Characteristic.CurrentHeatingCoolingState.HEAT,
+                );
+              } else if (
+                namespace === alexaNamespace &&
+                name === alexaValueNameCool
+              ) {
+                return O.of(
+                  this.Characteristic.CurrentHeatingCoolingState.COOL,
+                );
+              }
             }
             return O.none;
           }),


### PR DESCRIPTION
# Description

After updating to the latest version I noticed that my thermostat in KH showed "Cooling off to X" despite being in the HEAT state, confirmed by the Alexa app too.

The code was looking for the first entry in the state that matched the namespace `Alexa.ThermostatController.HVAC.Components` with name being either `primaryHeaterOperation` or `coolerOperation`, without considering its actual status.
In the json returned by my Alexa API there were two entries matching those criteria, but the `coolerOperation` one appeared first and got therefore matched as the current state despite being `OFF`

```json
...
  {
    "namespace": "Alexa.ThermostatController.HVAC.Components",
    "name": "coolerOperation",
    "value": "OFF"
  },
...
  {
    "namespace": "Alexa.ThermostatController.HVAC.Components",
    "name": "primaryHeaterOperation",
    "value": "STAGE_1"
  },
```

I changed the code to match any entry that is not set to `OFF`, built and test locally and the current state is now properly displayed.