### PR TITLE
Added ability to disable certain operations for devices

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -10,8 +10,10 @@
         "description": "List of smart home device names to add as HomeKit accessories. If no devices are specified, the plugin will attempt to add all supported accessories.",
         "type": "array",
         "uniqueItems": true,
-        "required": true,
         "default": [],
+        "condition": {
+          "functionBody": "return model.excludeDevices === undefined;"
+        },
         "items": {
           "title": "Device name",
           "type": "string"
@@ -22,8 +24,10 @@
         "description": "List of smart home device names to exclude from being added as HomeKit accessories. Exclude devices will only be excluded if 'Include device names' is empty.",
         "type": "array",
         "uniqueItems": true,
-        "required": true,
         "default": [],
+        "condition": {
+          "functionBody": "return model.devices === undefined;"
+        },
         "items": {
           "title": "Device name",
           "type": "string"
@@ -109,6 +113,26 @@
             "minimum": 30,
             "maximum": 3600,
             "default": 60
+          }
+        }
+      },
+      "disabledOperations": {
+        "title": "Disable Features",
+        "description": "Turn off specific device capabilities",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "deviceName": {
+              "title": "Device name",
+              "type": "string"
+            },
+            "operations": {
+              "title": "Disabled operations",
+              "type": "string",
+              "placeholder": "Comma separated list, e.g., setBrightness, setColor, setColorTemperature",
+              "pattern": "^(\\w+)(,\\s*\\w+)*$"
+            }
           }
         }
       },

--- a/src/accessory/base-accessory.ts
+++ b/src/accessory/base-accessory.ts
@@ -157,6 +157,12 @@ export default abstract class BaseAccessory {
     return this.service.getCharacteristic(characteristic)?.value ?? null;
   }
 
+  removeCharacteristic(char: Parameters<Service['testCharacteristic']>[0] & Parameters<Service['getCharacteristic']>[0]) {
+    if (this.service.testCharacteristic(char)) {
+      this.service.removeCharacteristic(this.service.getCharacteristic(char)!);
+    }
+  }
+
   get serviceCommunicationError() {
     this.logWithContext('debug', 'Service communication error');
     return new this.platform.HAP.HapStatusError(

--- a/src/accessory/base-accessory.ts
+++ b/src/accessory/base-accessory.ts
@@ -157,7 +157,10 @@ export default abstract class BaseAccessory {
     return this.service.getCharacteristic(characteristic)?.value ?? null;
   }
 
-  removeCharacteristic(char: Parameters<Service['testCharacteristic']>[0] & Parameters<Service['getCharacteristic']>[0]) {
+  removeCharacteristic(
+    char: Parameters<Service['testCharacteristic']>[0] &
+      Parameters<Service['getCharacteristic']>[0],
+  ) {
     if (this.service.testCharacteristic(char)) {
       this.service.removeCharacteristic(this.service.getCharacteristic(char)!);
     }

--- a/src/accessory/light-accessory.ts
+++ b/src/accessory/light-accessory.ts
@@ -33,6 +33,8 @@ export default class LightAccessory extends BaseAccessory {
         .getCharacteristic(this.Characteristic.Brightness)
         .onGet(this.handleBrightnessGet.bind(this))
         .onSet(this.handleBrightnessSet.bind(this));
+    } else {
+      this.removeCharacteristic(this.Characteristic.Brightness);
     }
 
     if (this.device.supportedOperations.includes('setColor')) {
@@ -44,6 +46,9 @@ export default class LightAccessory extends BaseAccessory {
         .getCharacteristic(this.Characteristic.Saturation)
         .onGet(this.handleSaturationGet.bind(this))
         .onSet(constVoid);
+    } else {
+      this.removeCharacteristic(this.Characteristic.Hue);
+      this.removeCharacteristic(this.Characteristic.Saturation);
     }
 
     if (this.device.supportedOperations.includes('setColorTemperature')) {
@@ -51,6 +56,8 @@ export default class LightAccessory extends BaseAccessory {
         .getCharacteristic(this.Characteristic.ColorTemperature)
         .onGet(this.handleColorTemperatureGet.bind(this))
         .onSet(this.handleColorTemperatureSet.bind(this));
+    } else {
+      this.removeCharacteristic(this.Characteristic.ColorTemperature);
     }
   }
 

--- a/src/domain/homebridge/index.ts
+++ b/src/domain/homebridge/index.ts
@@ -25,5 +25,13 @@ export interface AlexaPlatformConfig extends PlatformConfig {
   performance: Nullable<{
     cacheTTL: Nullable<number>;
   }>;
+  disabledOperations: Nullable<
+    [
+      {
+        deviceName: string;
+        operations: Nullable<string>;
+      },
+    ]
+  >;
   debug: Nullable<boolean>;
 }

--- a/src/domain/homebridge/index.ts
+++ b/src/domain/homebridge/index.ts
@@ -26,12 +26,10 @@ export interface AlexaPlatformConfig extends PlatformConfig {
     cacheTTL: Nullable<number>;
   }>;
   disabledOperations: Nullable<
-    [
-      {
-        deviceName: string;
-        operations: Nullable<string>;
-      },
-    ]
+    Array<{
+      deviceName: string;
+      operations: Nullable<string>;
+    }>
   >;
   debug: Nullable<boolean>;
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -295,11 +295,15 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
         constant([] as { deviceName: string; operations?: string | null }[]),
       ),
       A.map(
-        ({ deviceName: deviceName, operations }) =>
+        ({ deviceName, operations }) =>
           [deviceName.trim(), operations] as const,
       ),
       A.reduce(new Map<string, string[]>(), (map, [name, ops]) => {
-        map.set(name, ops?.split(',').map((o) => o.trim()) ?? []);
+        map.set(
+          name,
+          ops?.split(',').map((o) => o.trim()).filter((o) => o.length > 0) ??
+            [],
+        );
         return map;
       }),
     );


### PR DESCRIPTION
# Description

I have a few lights in my house for which I don't need the ability to change brightness/colors. This PR adds the ability to supply a list of operations to disable.

Although this currently only affects `light-accessory`, I have implemented it generically so that it can be used for other operation disabling in the future.

I also made a small additional change to `config.schema.json` to show/hide the Include and Exclude device sections so that only one can be supplied, but not both. This has the effect of showing that the config is "valid" (green checkmark) when everything else is correctly supplied.

Happy to make any changes you would like to see. Thanks for considering!

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing by supplying one more of  "setBrightness", "setColor", and "setColorTemperature" as `disabledOperations` and observing the results. Also tested not supplying anything to make sure it doesn't cause regressions

See before/after screenshots below.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~ No good place for this in the README, but happy to add if there is somewhere else
- [x] My changes generate no new warnings
- [ ] ~~New and existing unit tests pass locally with my changes~~ Tests failed even before making changes. None added.

<!-- Before you submit this PR, please make sure to read our [Contributing Guidelines](https://github.com/joeyhage/homebridge-alexa-smarthome/blob/main/CONTRIBUTING.md). -->

# Screenshots:

| Before | After |
| ------- | ----- |
| <img width="300" src="https://github.com/user-attachments/assets/413cdbeb-c605-4db2-8d76-67e9b75a533a" /> | <img width="300" src="https://github.com/user-attachments/assets/53972ddf-e51f-45ac-93ee-5ea6b3f45d69" /> |
| <img width="300" src="https://github.com/user-attachments/assets/38e5944c-fbb1-4efe-8da7-186260e63153" /> | <img width="300" src="https://github.com/user-attachments/assets/82417232-a655-4cdc-8170-0f7211b2be31" /> |

<img width="600" src="https://github.com/user-attachments/assets/bed4a399-21a3-4870-bee9-008488b52267" />
