### PR TITLE
Reduce logging of typical events

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -129,7 +129,7 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
   }
 
   configureAccessory(accessory: PlatformAccessory) {
-    this.log.info('Loading accessory from cache:', accessory.displayName)();
+    this.log.debug('Loading accessory from cache:', accessory.displayName)();
     this.cachedAccessories.push(accessory);
   }
 
@@ -140,7 +140,7 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
     this.alexaRemote.on('cookie', () => {
       const cookieData = this.alexaRemote.cookieData;
       if (util.isValidAuthentication(cookieData as unknown as J.Json)) {
-        this.log.info(
+        this.log.debug(
           'Alexa login cookie updated. Storing cookie in file:',
           this.cookiePersistPath,
         )();
@@ -378,7 +378,7 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
       !acc.context?.deviceType ||
       !acc.context?.homebridgeDeviceType
     ) {
-      this.log.info('Update accessory context:', acc.displayName)();
+      this.log.debug('Update accessory context:', acc.displayName)();
       acc.context = {
         ...acc.context,
         deviceId: device.id,
@@ -393,7 +393,7 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
         AccessoryFactory.createAccessory(this, acc, device, hbDeviceType),
       ),
       IOE.tapIO(() =>
-        this.log.info(
+        this.log.debug(
           'Restored existing accessory from cache:',
           device.displayName,
         ),


### PR DESCRIPTION
# Description

## Type of change

Personally, I'm a fan of the "silence is golden" philosophy. This PR reduces the log level of expected events (restoring accessories, updating cookie, etc.) from `info` to `debug`. This makes it easier to pick out atypical log messages, not necessarily just with your plugin, but with other plugins also.

# How Has This Been Tested?

Manual testing, very safe change if you agree with the philosophy

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (N/A)

<!-- Before you submit this PR, please make sure to read our [Contributing Guidelines](https://github.com/joeyhage/homebridge-alexa-smarthome/blob/main/CONTRIBUTING.md). -->
