### PR TITLE
fix: preserve cached device state when API returns null powerStateValue

### DIFF
--- a/src/accessory/base-accessory.ts
+++ b/src/accessory/base-accessory.ts
@@ -124,6 +124,11 @@ export default abstract class BaseAccessory {
       TE.map(([fromCache, states]) => {
         if (!fromCache) {
           this.lastUpdated = new Date();
+          if (states.length === 0) {
+            return this.platform.deviceStore.getCacheStatesForDevice(
+              this.device.id,
+            ) as unknown as S[];
+          }
         }
         return states;
       }),

--- a/src/wrapper/alexa-api-wrapper.ts
+++ b/src/wrapper/alexa-api-wrapper.ts
@@ -110,9 +110,11 @@ export class AlexaApiWrapper {
               2,
             )}`,
           );
-          this.deviceStore.updateCache([d.id], {
-            [d.id]: O.of(states.map(E.right)),
-          });
+          if (states.length > 0) {
+            this.deviceStore.updateCache([d.id], {
+              [d.id]: O.of(states.map(E.right)),
+            });
+          }
         });
         return this.log.debug(
           'Successfully obtained devices and their capabilities',
@@ -185,9 +187,11 @@ export class AlexaApiWrapper {
               ),
               TE.map((_) => extractStates(_.data.endpoint.features)),
               TE.map((states) => {
-                this.deviceStore.updateCache([device.id], {
-                  [device.id]: O.of(states.map(E.right)),
-                });
+                if (states.length > 0) {
+                  this.deviceStore.updateCache([device.id], {
+                    [device.id]: O.of(states.map(E.right)),
+                  });
+                }
                 return [false, states] as [boolean, CapabilityState[]];
               }),
             ),


### PR DESCRIPTION
# Description

Devices that support power operations but don't report state (powerStateValue is null) were poisoning the cache with empty arrays on every API query. After cache TTL expired, the accessory would fail with "State not available" even though the cache held a valid last-known state from a prior setPower command.

Skip cache updates when extractStates returns empty, and fall back to cached state in getStateGraphQl when the live API response has no states.

Fixes # (issue): #196 is the issue I'm having with a switch, but since it's old, then I'm unsure if it's related.  #263 seems to be the most recent complaint of`get power` returning an invalid response. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the plugin for a while, notice that HomeKit eventually reports the state for the device cannot be updated.   Logs would report:

```
[6/1/2026, 9:22:20 AM] [homebridge-alexa-smarthome] Soldering Iron - Get power - InvalidResponse(State not available)
```
With debugging on:

```
[6/7/2026, 10:00:28 AM] [homebridge-alexa-smarthome] Soldering Iron ::: Raw device features: [
  { 
    "name": "power",
    "instance": null,
    "operations": [
      {
        "name": "turnOn"
      },
      {
        "name": "turnOff"
      }
    ],
    "properties": [
      {
        "name": "powerState", 
        "powerStateValue": null
      }
    ],
....
```

Note the `powerStateValue: null`.

After the patch, a null value wouldn't poison the cache and you can control the device to put it into a known state.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
