### PR TITLE
Avoid post-write state queries when setting light color

### DIFF
--- a/src/accessory/light-accessory.ts
+++ b/src/accessory/light-accessory.ts
@@ -199,15 +199,33 @@ export default class LightAccessory extends BaseAccessory {
           this.logWithContext('errorT', 'Set hue', e);
           throw this.serviceCommunicationError;
         },
-        async () => {
-          this.updateCacheValue({
-            value: {
-              hue: value,
-              saturation: await this.handleSaturationGet(),
-              brightness: await this.handleBrightnessGet(),
-            },
-            featureName: 'color',
-          });
+        () => {
+          pipe(
+            this.getCacheValue('color'),
+            O.filter(
+              (
+                color,
+              ): color is {
+                brightness: number;
+                hue: number;
+                saturation: number;
+              } =>
+                typeof color === 'object' &&
+                color !== null &&
+                typeof color.brightness === 'number' &&
+                typeof color.hue === 'number' &&
+                typeof color.saturation === 'number',
+            ),
+            O.map((color) =>
+              this.updateCacheValue({
+                value: {
+                  ...color,
+                  hue: value,
+                },
+                featureName: 'color',
+              }),
+            ),
+          );
         },
       ),
     )();


### PR DESCRIPTION
Some Alexa-connected color lights accept `setColor` successfully but do not
return a usable color state through the state API.

After a successful hue write, `handleHueSet()` currently calls
`handleSaturationGet()` and `handleBrightnessGet()` to rebuild the cached
color value. If either state is unavailable, the successful color command is
reported to HomeKit as a service communication failure.

This change avoids those post-write API reads. It updates the hue in the
existing cached color state when one is available, while allowing the
successful color write to complete even when Alexa cannot report hue or
saturation.

Observed before this change:

- The physical lamp changed color successfully.
- Alexa returned `State not available` for saturation.
- HomeKit displayed a service communication error.

Observed after this change:

- The physical lamp changes color successfully.
- No follow-up saturation/brightness query is made.
- The HomeKit write completes without a service communication error.

`npm run build` completes successfully. The existing light accessory tests on
the current main branch appear to be stale relative to the current API and
configuration types.