### PR TITLE
fix: correct amazonPage from saved cookie data on domain mismatch

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -169,13 +169,22 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
     pipe(
       util.getAuthentication(this.cookiePersistPath),
       IOE.match(logStoredAuthErrors, identity),
-      IO.map((auth) =>
-        this.alexaRemote.init(
+      IO.map((auth) => {
+        // Prefer the marketplace from saved cookie data over the config.
+        const effectiveDomain =
+          auth?.amazonPage && auth.amazonPage !== amazonDomain
+            ? (this.log.debug(
+                `amazonPage corrected: "${amazonDomain}" → "${auth?.amazonPage}"`,
+              ),
+              auth.amazonPage)
+            : amazonDomain;
+
+        return this.alexaRemote.init(
           {
             acceptLanguage:
               this.config.language ?? settings.DEFAULT_ACCEPT_LANG,
-            alexaServiceHost: `alexa.${amazonDomain}`,
-            amazonPage: amazonDomain,
+            alexaServiceHost: `alexa.${effectiveDomain}`,
+            amazonPage: effectiveDomain,
             amazonPageProxyLanguage:
               this.config.language?.replace('-', '_') ??
               settings.DEFAULT_PROXY_PAGE_LANG,
@@ -210,8 +219,8 @@ export class AlexaSmartHomePlatform implements DynamicPlatformPlugin {
               ),
             );
           },
-        ),
-      ),
+        );
+      }),
     )();
   }
 


### PR DESCRIPTION
## Description

When saved authentication data contains an `amazonPage` (set by Amazon's `getUserData`) that differs from the configured domain, prefer the cookie's value. Otherwise the domain mismatch causes the token refresh `/auth/register` call to fail with `InvalidToken`.

Fixes # (no issue filed yet)

## Type of change

- [x] Bug fix

## How Has This Been Tested?

Domain correction logic verified via `npm run build` (passes clean, no new warnings).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes