### PR TITLE
Include hidden `name` field in config schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -5,6 +5,13 @@
   "schema": {
     "type": "object",
     "properties": {
+      "name": {
+        "type": "string",
+        "default": "HomebridgeAlexaSmartHome",
+        "condition": {
+          "functionBody": "return false;"
+        }
+      },
       "devices": {
         "title": "Include device names",
         "description": "List of smart home device names to add as HomeKit accessories. If no devices are specified, the plugin will attempt to add all supported accessories.",


### PR DESCRIPTION
# Description

By default, Homebridge Alexa Smarthome log messages look like this:

`[6/16/2026, 10:34:20 AM] [HomebridgeAlexaSmartHome] Initializing HomebridgeAlexaSmartHome platform...`

I like to have the log message tag match the name of my child bridge, e.g.

`[6/16/2026, 10:35:07 AM] [Alexa] Initializing HomebridgeAlexaSmartHome platform...`

I do this by adding a "name" field into my JSON config, e.g.

```json
{
    "name": "Alexa", <--- HERE
    "amazonDomain": "amazon.com",
    "language": "en-US",
    "auth": {
        "refreshInterval": 4,
        "proxy": {
            "clientHost": "localhost",
            "port": 9000
        }
    },
    "performance": {
        "cacheTTL": 60
    },
    "debug": false,
    "platform": "HomebridgeAlexaSmartHome"
}
```

The problem is that whenever I edit the config in the UI editor, the `name` field is removed because it is not expected.

This PR solves the problem by adding a `name` field that is always hidden. That way, it can be updated in the JSON without being overwritten by the config UI.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing:
- Removed `name` -> verified that it is re-added by the config UI
- Changed `name` field ->  verify that it's not overwritten by subsequent config UI saves
- Verified that the `name` causes the log messages to change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
[ N/A ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes